### PR TITLE
Allow resolving worker queues from application config

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -22,8 +22,17 @@ export class Worker {
     const config = this.app.config.get<ReturnType<typeof defineConfig>>('jobs', {})
     const logger = await this.app.container.make('logger')
     const jobs = await this.app.container.make('jobs.list')
-    const queues =
-      this.config.queues && this.config.queues.length ? this.config.queues : [config.queue]
+
+    let queues: string[]
+
+    if (this.config.queues && this.config.queues.length > 0) {
+      queues = this.config.queues
+    } else if (config.queues && config.queues.length > 0) {
+      queues = config.queues
+    } else {
+      queues = [config.queue]
+    }
+
     const workers: BullWorker[] = []
     const revivers = {
       ...REVIVERS,


### PR DESCRIPTION
### What changed

This PR allows worker queues to be resolved from the application configuration (`config.queues`) when the `--queue` CLI flag is not provided.

Currently, multiple queues are only supported when explicitly passed via CLI. When the flag is omitted, the worker always falls back to `config.queue`, even if `config.queues` is defined.

This change introduces a clear priority order:

1. CLI flag (`--queue`) — explicit override  
2. Application config (`config.queues`) — runtime/bootstrap configuration  
3. Fallback (`config.queue`) — existing behavior  

### Why this is useful

This enables defining worker queues via application configuration at process startup, keeping the command invocation fixed (e.g. `node ace jobs:listen`).

This follows the same pattern used by other AdonisJS queue integrations (e.g. rlanz/bull-queue), where the CLI acts as an explicit override, and application configuration is used when no queues are provided via the command.

### Backward compatibility

- No breaking changes
- Existing CLI behavior is preserved
- Existing fallback behavior remains unchanged
